### PR TITLE
Fix model loading in prediction script

### DIFF
--- a/src/interface/predict.py
+++ b/src/interface/predict.py
@@ -9,12 +9,16 @@ import pandas as pd
 import numpy as np
 
 from src.utils.io import read_data
+from src.models.lgbm_model import LGBMWrapper
 
 
 def load_models(path: Path):
-    models = []
+    """Load all LightGBM wrapper models from the given directory."""
+    models: list[LGBMWrapper] = []
     for p in glob.glob(str(path / "lgbm_fold*.pkl")):
-        models.append(joblib.load(p))
+        wrapper = LGBMWrapper(params={})
+        wrapper.load(Path(p))
+        models.append(wrapper)
     return models
 
 


### PR DESCRIPTION
## Summary
- load saved LightGBM wrappers correctly when predicting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas>=2.2)*

------
https://chatgpt.com/codex/tasks/task_e_684e7d883640832d8a4d859485f3ea97