### PR TITLE
Fix rolling features for test data

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # preprocess.sh
 python -m src.features.build_features --input data/raw/train.csv --split train
-python -m src.features.build_features --input data/raw/test.csv  --split test
+python -m src.features.build_features --input data/raw/test.csv  --split test --train data/raw/train.csv

--- a/src/features/build_features.py
+++ b/src/features/build_features.py
@@ -58,11 +58,34 @@ def add_rolling(df: pd.DataFrame) -> pd.DataFrame:
 
 def main(args):
     df = pd.read_csv(args.input)
+
+    # If we are preparing test features and a training file is provided,
+    # prepend the last week of training data so that lag/rolling features
+    # can be computed without losing the first test rows.
+    if args.split == "test" and args.train is not None:
+        df_tr = pd.read_csv(args.train)
+        window = max(DEF_LAGS)
+        df_tr = df_tr.tail(window)
+        df_tr["__split"] = "train"
+        df["__split"] = "test"
+        df = pd.concat([df_tr, df], ignore_index=True)
+    else:
+        df["__split"] = args.split
+
     df = add_time_features(df)
     df = add_lag_features(df, DEF_LAGS)
     df = add_rolling(df)
-    # drop rows with NaNs created by lagging
+
+    # drop rows with NaNs created by lagging/rolling
     df = df.dropna().reset_index(drop=True)
+
+    # if extra training rows were prepended, keep only test part
+    if "__split" in df.columns and args.split == "test":
+        df = df[df["__split"] == "test"].reset_index(drop=True)
+        df = df.drop(columns=["__split"])
+    elif "__split" in df.columns:
+        df = df.drop(columns=["__split"])
+
     from src.utils.io import save_data
     save_data(df, args.split)
 
@@ -70,5 +93,6 @@ if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("--input", type=Path, required=True)
     p.add_argument("--split", type=str, choices=["train", "test"], required=True)
+    p.add_argument("--train", type=Path, help="Path to raw training CSV used for computing initial lags in test mode")
     args = p.parse_args()
     main(args)

--- a/src/interface/predict.py
+++ b/src/interface/predict.py
@@ -51,7 +51,7 @@ def main(args):
     # 5) 提出ファイル
     sub = pd.DataFrame({"time": df["time"], "price_actual": preds})
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
-    sub.to_csv(args.out, index=False)
+    sub.to_csv(args.out, index=False, header=False)
     print("Saved submission to", args.out)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- append trailing train rows when creating test features so rolling lag values exist
- call build_features with the train path for the test split
- drop CSV headers in prediction output

## Testing
- `pytest -q`
- `python -m py_compile src/features/build_features.py src/interface/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8689d450832dbc9f2bdb93e175b5