### PR TITLE
Fix rolling features for test data

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # preprocess.sh
 python -m src.features.build_features --input data/raw/train.csv --split train
-python -m src.features.build_features --input data/raw/test.csv  --split test
+python -m src.features.build_features --input data/raw/test.csv  --split test --train data/raw/train.csv

--- a/src/interface/predict.py
+++ b/src/interface/predict.py
@@ -51,7 +51,7 @@ def main(args):
     # 5) 提出ファイル
     sub = pd.DataFrame({"time": df["time"], "price_actual": preds})
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
-    sub.to_csv(args.out, index=False)
+    sub.to_csv(args.out, index=False, header=False)
     print("Saved submission to", args.out)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- append trailing train rows when creating test features so rolling lag values exist
- call build_features with the train path for the test split
- drop CSV headers in prediction output
- avoid dropping test rows by removing target column when combining with training data

## Testing
- `python -m py_compile src/features/build_features.py src/interface/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8689d450832dbc9f2bdb93e175b5