### PR TITLE
Add Hydra-based config management

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,0 +1,7 @@
+cfg: src/config/lgbm_baseline.yaml
+input: data/train/train.pkl
+model_dir: models
+
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ holidays>=0.41
 pyarrow==16.1.0
 xgboost>=2.0
 darts>=0.27.0
+hydra-core>=1.3

--- a/scripts/train_lgbm.sh
+++ b/scripts/train_lgbm.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # train_lgbm.sh
 python -m src.training.train_model \
-  --cfg src/config/lgbm_baseline.yaml \
-  --input data/train/train.pkl \
-  --model_dir output/models
+  cfg=src/config/lgbm_baseline.yaml \
+  input=data/train/train.pkl

--- a/scripts/train_nlinear.sh
+++ b/scripts/train_nlinear.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # train_nlinear.sh
 python -m src.training.train_model \
-  --cfg src/config/nlinear.yaml \
-  --input data/train/train.pkl \
-  --model_dir output/models
+  cfg=src/config/nlinear.yaml \
+  input=data/train/train.pkl

--- a/scripts/train_wf_lgbm.sh
+++ b/scripts/train_wf_lgbm.sh
@@ -13,9 +13,8 @@ set -euo pipefail
 CFG_PATH=${1:-src/config/lgbm_baseline.yaml}
 RAW_DIR="data"
 PROCESSED_DIR="${RAW_DIR}/train"
-MODEL_DIR="output/models_wf"
 
 python -m src.training.train_model_wf \
-    --cfg "${CFG_PATH}" \
-    --input "${PROCESSED_DIR}/train.pkl" \
-    --model_dir "${MODEL_DIR}"
+    cfg="${CFG_PATH}" \
+    input="${PROCESSED_DIR}/train.pkl" \
+    model_dir=models_wf

--- a/scripts/train_xgb.sh
+++ b/scripts/train_xgb.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # train.sh
 python -m src.training.train_model \
-  --cfg src/config/xgb_baseline.yaml \
-  --input data/train/train.pkl \
-  --model_dir output/models
+  cfg=src/config/xgb_baseline.yaml \
+  input=data/train/train.pkl


### PR DESCRIPTION
## Summary
- integrate Hydra into training scripts
- add Hydra config file and update requirements
- update training shell scripts to use Hydra

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ec0cac61c832da09d7d29ececbfe2