### PR TITLE
Enable Hydra-based inference

### DIFF
--- a/conf/predict.yaml
+++ b/conf/predict.yaml
@@ -1,0 +1,6 @@
+models: models
+input: null
+out: output/submissions/submission.csv
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/scripts/predict.sh
+++ b/scripts/predict.sh
@@ -1,3 +1,20 @@
-#!/bin/bash
-# predict.sh
-python -m src.interface.predict --models output/models --input data/test/test.pkl --out output/submissions/submission.csv
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# predict.sh – Generate predictions with Hydra-managed configuration
+# ---------------------------------------------------------------------------
+# Usage:
+#     bash scripts/predict.sh <model_dir> <out_csv>
+#
+# Example:
+#     bash scripts/predict.sh outputs/2023-10-05/15-00-00/models \
+#         outputs/submissions/submission.csv
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+MODEL_DIR=${1:-models}
+OUT_PATH=${2:-outputs/submissions/submission.csv}
+
+python -m src.interface.predict \
+    models="${MODEL_DIR}" \
+    input=data/test/test.pkl \
+    out="${OUT_PATH}"


### PR DESCRIPTION
## Summary
- support Hydra execution for predictions
- add configuration for prediction settings
- update helper script to use Hydra

## Testing
- `python -m src.interface.predict --help` *(fails: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_684ec71b64d0832db7bebeecf0da9092